### PR TITLE
fix(coc-api): rename language client  to `sumneko_lua`

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -39,7 +39,7 @@ export class Ctx {
   }
 
   registerCommand(name: string, factory: (ctx: Ctx) => Cmd, internal = false) {
-    const fullName = `sumneko-lua.${name}`;
+    const fullName = `sumneko_lua.${name}`;
     const cmd = factory(this);
     const d = commands.registerCommand(fullName, cmd, null, internal);
     this.extCtx.subscriptions.push(d);
@@ -176,7 +176,7 @@ export class Ctx {
         },
       },
     };
-    return new LanguageClient('sumneko-lua', 'Sumneko Lua Language Server', serverOptions, clientOptions);
+    return new LanguageClient('sumneko_lua', 'Sumneko Lua Language Server', serverOptions, clientOptions);
   }
 
   async startServer() {


### PR DESCRIPTION
The `coc_timer_diagnosticsumneko-lua` can't pass the variable legitimacy checking after the commit on coc.nvim: https://github.com/neoclide/coc.nvim/blame/459ab648b6f1f1188d091331733f0894e077db40/autoload/coc/highlight.vim#L24

```log
ERROR (pid:53975) [node-client] - request error 0 on "nvim_call_function" [
  'coc#highlight#buffer_update',
  [ 39, 'diagnosticsumneko-lua', [ [Array], [Array] ], 4096, null ]
] Vim(call):E461: Illegal variable name: coc_timer_diagnosticsumneko-lua Error
    at YA.resumeNotification (~/.local/share/nvim/site/pack/packer/opt/coc.nvim/build/index.js:31:1228)
    at cF.resumeNotification (~/.local/share/nvim/site/pack/packer/opt/coc.nvim/build/index.js:34:5229)
    at k_._refresh (~/.local/share/nvim/site/pack/packer/opt/coc.nvim/build/index.js:194:2978)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async k_.refresh (~/.local/share/nvim/site/pack/packer/opt/coc.nvim/build/index.js:194:2114)
```