### PR TITLE
fix: added fix for downloader if on not supported OS

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,6 +1,6 @@
-import { ExtensionContext, window } from 'coc.nvim';
+import {ExtensionContext, window} from 'coc.nvim';
 import extract from 'extract-zip';
-import fetch, { Response } from 'node-fetch';
+import fetch, {Response} from 'node-fetch';
 import path from 'path';
 import * as fs from 'fs-extra';
 import * as os from 'os';
@@ -50,7 +50,10 @@ export async function getLatestRelease(): Promise<Release | undefined> {
     return;
   }
 
-  const targetPlatform = `${os.platform()}-${os.arch()}`;
+  const osPlatform = ['linux', 'darwin', 'win32'].includes(os.platform())
+    ? os.platform()
+    : 'linux';
+  const targetPlatform = `${osPlatform}-${os.arch()}`;
 
   const release = await response.json();
 
@@ -63,7 +66,7 @@ export async function getLatestRelease(): Promise<Release | undefined> {
 }
 
 export async function downloadServer(context: ExtensionContext, release?: Release): Promise<void> {
-  const statusItem = window.createStatusBarItem(0, { progress: true });
+  const statusItem = window.createStatusBarItem(0, {progress: true});
   statusItem.show();
 
   if (!release) {
@@ -101,7 +104,7 @@ export async function downloadServer(context: ExtensionContext, release?: Releas
   await fs.remove(targetPath);
 
   statusItem.text = `Extracting to ${targetPath}`;
-  await extract(extTempFile, { dir: targetPath });
+  await extract(extTempFile, {dir: targetPath});
 
   const binPath = path.join(targetPath, 'extension', 'server', 'bin', 'lua-language-server');
   if (fs.existsSync(binPath)) {


### PR DESCRIPTION
If you try to use this package on a non supported system (I believe that would be anything that's not macos, win or linux. In my case FreeBSD) you get an error when downloading since there is not a version for that OS.

I added a modification so if you are in another OS that's not macos, win or linux you get the linux download. This works for FreeBSD and should work too for OpenBSD, thus, adding support for both.