### PR TITLE
fix: get correct release version of nvim when loading neodev.nvim

### DIFF
--- a/src/neodev.ts
+++ b/src/neodev.ts
@@ -39,7 +39,7 @@ export class Neodev {
       return path.join(
         this.repoDir,
         'types',
-        workspace.isNvim && Boolean(workspace.nvim.call('luaeval', 'vim.version().prerelease')) ? 'nightly' : 'stable'
+        workspace.isNvim && Boolean(await workspace.nvim.call('luaeval', 'vim.version().prerelease')) ? 'nightly' : 'stable'
       );
     } else {
       window.showWarningMessage('Please run command: installNvimLuaTypes');


### PR DESCRIPTION
`workspace.nvim.call()` returns a `Promise` object, converting a non-null `Promise` object to `boolean` always returns `true`.


closes #62 